### PR TITLE
feat: Add 'How to Use' sections and input validation

### DIFF
--- a/CaesarCipher.html
+++ b/CaesarCipher.html
@@ -53,6 +53,31 @@
         <p id="result"></p>
     </div>
 
+    <!-- "How to Use" Section -->
+    <div class="how-to-use-section">
+        <button class="expand-btn" onclick="toggleHowToUse()">How to Use</button>
+        <div class="collapse-content" id="howToUseContent">
+            <h3>Welcome to the Caesar Cipher Tool!</h3>
+            <p>The Caesar cipher is a simple substitution cipher where each letter in the plaintext is shifted a certain number of places down or up the alphabet.</p>
+
+            <h4>To Encrypt a Message:</h4>
+            <ol>
+                <li><strong>Enter a Message:</strong> Type the text you want to encrypt into the "Message" field.</li>
+                <li><strong>Set a Shift Value:</strong> Choose an integer for the "Shift Value." This is your key.</li>
+                <li><strong>Click Encrypt:</strong> The encrypted message will appear in the "Result" box.</li>
+            </ol>
+
+            <h4>To Decrypt a Message:</h4>
+            <ol>
+                <li><strong>Enter the Ciphertext:</strong> Paste the encrypted text into the "Message" field.</li>
+                <li><strong>Use the Same Shift Value:</strong> Enter the original key used for encryption.</li>
+                <li><strong>Click Decrypt:</strong> The original message will be revealed.</li>
+            </ol>
+
+            <p><strong>Tip:</strong> You can use the "Show/Hide Alphabet Tables" button to see how the alphabet is shifted based on your key.</p>
+        </div>
+    </div>
+
     <!-- Collapsible Section -->
     <div class="collapse-section">
         <button class="expand-btn" onclick="toggleCollapse()">Show/Hide Alphabet Tables</button>

--- a/CaesarCipher.js
+++ b/CaesarCipher.js
@@ -26,7 +26,14 @@
 // Function to encrypt and show results
 function performEncrypt() {
     const message = document.getElementById("message").value;
-    const shift = parseInt(document.getElementById("shift").value);
+    const shiftValue = document.getElementById("shift").value;
+
+    if (!message || !shiftValue) {
+        alert("Please enter a message and a shift value.");
+        return;
+    }
+
+    const shift = parseInt(shiftValue);
     const encryptedMessage = caesarCipher(message, shift);
     const resultBox = document.getElementById("resultBox");
 
@@ -42,7 +49,14 @@ function performEncrypt() {
 // Function to decrypt and show results
 function performDecrypt() {
     const message = document.getElementById("message").value;
-    const shift = parseInt(document.getElementById("shift").value);
+    const shiftValue = document.getElementById("shift").value;
+
+    if (!message || !shiftValue) {
+        alert("Please enter a message and a shift value.");
+        return;
+    }
+
+    const shift = parseInt(shiftValue);
     const decryptedMessage = caesarCipher(message, -shift);
     const resultBox = document.getElementById("resultBox");
 
@@ -94,4 +108,10 @@ function populateAlphabetTables(shift) {
 function toggleCollapse() {
     const collapseContent = document.getElementById("collapseContent");
     collapseContent.style.display = (collapseContent.style.display === "block") ? "none" : "block";
+}
+
+// Function to toggle the "How to Use" section
+function toggleHowToUse() {
+    const howToUseContent = document.getElementById("howToUseContent");
+    howToUseContent.style.display = (howToUseContent.style.display === "block") ? "none" : "block";
 }

--- a/Playfair.html
+++ b/Playfair.html
@@ -59,6 +59,33 @@
             <h2>Decryption Steps:</h2>
             <pre id="decryptionResultContent"></pre>
         </div>
+
+        <!-- "How to Use" Section -->
+        <div class="how-to-use-section">
+            <button class="expand-btn" onclick="toggleHowToUse()">How to Use</button>
+            <div class="collapse-content" id="howToUseContent">
+                <h3>Welcome to the Playfair Cipher Tool!</h3>
+                <p>The Playfair cipher is a digraphic substitution cipher that encrypts pairs of letters (digraphs) instead of single letters.</p>
+
+                <h4>To Encrypt a Message:</h4>
+                <ol>
+                    <li><strong>Select Operation:</strong> Choose "Encrypt".</li>
+                    <li><strong>Enter a Key:</strong> Provide a keyword. The key square will be generated based on this. You can also generate a random key.</li>
+                    <li><strong>Enter Plaintext:</strong> Type the message you want to encrypt.</li>
+                    <li><strong>Click Submit:</strong> The encryption steps and the final ciphertext will be displayed.</li>
+                </ol>
+
+                <h4>To Decrypt a Message:</h4>
+                <ol>
+                    <li><strong>Select Operation:</strong> Choose "Decrypt".</li>
+                    <li><strong>Use the Original Key:</strong> Enter the same key that was used for encryption.</li>
+                    <li><strong>Enter Ciphertext:</strong> Paste the encrypted text into the "Text" field.</li>
+                    <li><strong>Click Submit:</strong> The decryption steps and the original message will be revealed.</li>
+                </ol>
+
+                <p><strong>Note:</strong> The Playfair cipher uses a 5x5 grid of letters. 'J' is typically treated as 'I'.</p>
+            </div>
+        </div>
     </div>
 
     <script src="pf.js"></script>

--- a/Railfence.html
+++ b/Railfence.html
@@ -45,6 +45,24 @@
             <h3>Rail Fence Structure:</h3>
             <div id="fenceContainer"></div>
         </div>
+
+        <!-- "How to Use" Section -->
+        <div class="how-to-use-section">
+            <button class="expand-btn" onclick="toggleHowToUse()">How to Use</button>
+            <div class="collapse-content" id="howToUseContent">
+                <h3>Welcome to the Rail Fence Cipher Tool!</h3>
+                <p>The Rail Fence cipher is a form of transposition cipher that gets its name from the way in which it is encoded. The plaintext is written downwards and diagonally on successive "rails" of an imaginary fence.</p>
+
+                <h4>To Encrypt a Message:</h4>
+                <ol>
+                    <li><strong>Enter Plaintext:</strong> Type the message you want to encrypt in the text area.</li>
+                    <li><strong>Enter Number of Rails:</strong> Specify the number of rails to be used for the fence.</li>
+                    <li><strong>Click Encrypt:</strong> The encrypted message and the rail fence structure will be displayed.</li>
+                </ol>
+
+                <p><strong>Note:</strong> This tool currently only supports encryption.</p>
+            </div>
+        </div>
     </div>
 
     <script src="Railfence.js"></script>

--- a/Railfence.js
+++ b/Railfence.js
@@ -40,8 +40,14 @@ document.getElementById('cipherForm').addEventListener('submit', function(event)
     event.preventDefault(); // Prevent form submission
 
     const plaintext = document.getElementById('plaintext').value;
-    const rails = parseInt(document.getElementById('rails').value);
+    const railsValue = document.getElementById('rails').value;
 
+    if (!plaintext || !railsValue) {
+        alert("Please enter both plaintext and the number of rails.");
+        return;
+    }
+
+    const rails = parseInt(railsValue);
     const { ciphertext, fence } = railFenceEncrypt(plaintext, rails);
 
     // Display the results
@@ -65,3 +71,9 @@ menuBtn.addEventListener('click', function() {
     navMenu.classList.toggle('active');
 });
 */
+
+// Function to toggle the "How to Use" section
+function toggleHowToUse() {
+    const howToUseContent = document.getElementById("howToUseContent");
+    howToUseContent.style.display = (howToUseContent.style.display === "block") ? "none" : "block";
+}

--- a/hill.js
+++ b/hill.js
@@ -111,9 +111,23 @@ function runHillCipher(mode) {
     outputDiv.classList.remove('result-fade-in'); // Remove class if already present
     void outputDiv.offsetWidth; // Trigger reflow
 
+    // Validate key matrix
+    for (let row of keyMatrix) {
+        for (let cell of row) {
+            if (isNaN(cell)) {
+                alert("Please fill in the entire key matrix.");
+                return;
+            }
+        }
+    }
+
     if (mode === 'encrypt') {
         // Encryption logic
         let plaintext = document.getElementById("plaintext").value.toUpperCase().replace(/\s+/g, '');
+        if (!plaintext) {
+            alert("Please enter plaintext.");
+            return;
+        }
         plaintext = padPlaintext(plaintext, matrixSize);
         const parts = divideString(plaintext, matrixSize);
         let ciphertext = '';
@@ -145,6 +159,10 @@ function runHillCipher(mode) {
     } else if (mode === 'decrypt') {
         // Decryption logic
         let ciphertext = document.getElementById("ciphertext").value.toUpperCase().replace(/\s+/g, '');
+        if (!ciphertext) {
+            alert("Please enter ciphertext.");
+            return;
+        }
         const inverseKeyMatrix = inverseMatrix(keyMatrix);  // Calculate inverse key matrix
         const parts = divideString(ciphertext, matrixSize);
         let decryptedText = '';
@@ -200,4 +218,10 @@ function generateRandomPlaintext() {
     }
 
     document.getElementById("plaintext").value = randomPlaintext; // Set the generated random plaintext
+}
+
+// Function to toggle the "How to Use" section
+function toggleHowToUse() {
+    const howToUseContent = document.getElementById("howToUseContent");
+    howToUseContent.style.display = (howToUseContent.style.display === "block") ? "none" : "block";
 }

--- a/index.html
+++ b/index.html
@@ -66,6 +66,32 @@
             <h2>Output:</h2>
             <div class="output" id="output"></div>
         </div>
+
+        <!-- "How to Use" Section -->
+        <div class="how-to-use-section">
+            <button class="expand-btn" onclick="toggleHowToUse()">How to Use</button>
+            <div class="collapse-content" id="howToUseContent">
+                <h3>Welcome to the Hill Cipher Tool!</h3>
+                <p>The Hill cipher is a polygraphic substitution cipher based on linear algebra. Each letter is represented by a number, and a matrix is used as the key.</p>
+
+                <h4>To Encrypt a Message:</h4>
+                <ol>
+                    <li><strong>Set Matrix Size:</strong> Choose a size for the key matrix (e.g., 2 for a 2x2 matrix).</li>
+                    <li><strong>Enter Key Matrix:</strong> Fill in the key matrix with numbers. The matrix must be invertible for decryption to be possible. You can also generate a random key.</li>
+                    <li><strong>Enter Plaintext:</strong> Type the message you want to encrypt. It will be automatically padded if its length isn't a multiple of the matrix size.</li>
+                    <li><strong>Click Encrypt:</strong> The encrypted message will appear in the "Output" box.</li>
+                </ol>
+
+                <h4>To Decrypt a Message:</h4>
+                <ol>
+                    <li><strong>Set Matrix Size and Key:</strong> Use the same matrix size and key that were used for encryption.</li>
+                    <li><strong>Enter Ciphertext:</strong> Paste the encrypted text into the "Ciphertext" field.</li>
+                    <li><strong>Click Decrypt:</strong> The original message will be revealed in the "Output" box.</li>
+                </ol>
+
+                <p><strong>Note:</strong> The determinant of the key matrix must not be zero and must not share any common factors with 26 for the cipher to be decryptable.</p>
+            </div>
+        </div>
     </div>
     <script src="hill.js"></script>
     <script src="shared.js" defer></script>

--- a/otp.html
+++ b/otp.html
@@ -49,6 +49,33 @@
         </form>
 
         <div id="output" class="output"></div>
+
+        <!-- "How to Use" Section -->
+        <div class="how-to-use-section">
+            <button class="expand-btn" onclick="toggleHowToUse()">How to Use</button>
+            <div class="collapse-content" id="howToUseContent">
+                <h3>Welcome to the One-Time Pad (OTP) Cipher Tool!</h3>
+                <p>The One-Time Pad is an unbreakable cipher that requires a random key as long as the message. Each character is combined with a key character to produce the ciphertext.</p>
+
+                <h4>To Encrypt a Message:</h4>
+                <ol>
+                    <li><strong>Enter Plaintext:</strong> Type the message you want to encrypt in the "Text" field.</li>
+                    <li><strong>Enter Key:</strong> Provide a key that is at least as long as the plaintext. You can also generate a random key.</li>
+                    <li><strong>Select Mode:</strong> Choose "Encrypt".</li>
+                    <li><strong>Click Submit:</strong> The encrypted message will appear in the output box.</li>
+                </ol>
+
+                <h4>To Decrypt a Message:</h4>
+                <ol>
+                    <li><strong>Enter Ciphertext:</strong> Paste the encrypted text into the "Text" field.</li>
+                    <li><strong>Use the Original Key:</strong> Enter the exact same key that was used for encryption.</li>
+                    <li><strong>Select Mode:</strong> Choose "Decrypt".</li>
+                    <li><strong>Click Submit:</strong> The original message will be revealed.</li>
+                </ol>
+
+                <p><strong>Security Note:</strong> A key should never be reused. For true one-time pad security, the key must be random, used only once, and kept secret.</p>
+            </div>
+        </div>
     </div>
 
     <script src="otp.js"></script>

--- a/otp.js
+++ b/otp.js
@@ -86,6 +86,12 @@ document.getElementById('cipherForm').addEventListener('submit', function(event)
 
     const plaintext = document.getElementById('plaintext').value.toLowerCase().replace(/\s+/g, ''); // Remove spaces
     const key = document.getElementById('key').value.toLowerCase().replace(/\s+/g, ''); // Remove spaces
+
+    if (!plaintext || !key) {
+        alert("Please enter both text and a key.");
+        return;
+    }
+
     const mode = document.querySelector('input[name="mode"]:checked').value; // Get encryption or decryption mode
 
     let result;
@@ -176,4 +182,10 @@ function generateRandomKey() {
     }
 
     document.getElementById('key').value = randomKey; // Set the generated key
+}
+
+// Function to toggle the "How to Use" section
+function toggleHowToUse() {
+    const howToUseContent = document.getElementById("howToUseContent");
+    howToUseContent.style.display = (howToUseContent.style.display === "block") ? "none" : "block";
 }

--- a/pf.js
+++ b/pf.js
@@ -105,6 +105,11 @@ document.getElementById('cipherForm').addEventListener('submit', function(event)
     const key = document.getElementById('key').value;
     const text = document.getElementById('plaintext').value;
 
+    if (!key || !text) {
+        alert("Please enter both a key and text.");
+        return;
+    }
+
     if (operation === 'encrypt') {
         const { result: encResult, ciphertext } = playfairEncrypt(text, key);
         const resultBox = document.getElementById('resultBox');
@@ -223,3 +228,9 @@ menuBtn.addEventListener('click', function() {
     navMenu.classList.toggle('active');
 });
 */
+
+// Function to toggle the "How to Use" section
+function toggleHowToUse() {
+    const howToUseContent = document.getElementById("howToUseContent");
+    howToUseContent.style.display = (howToUseContent.style.display === "block") ? "none" : "block";
+}


### PR DESCRIPTION
Adds a collapsible 'How to Use' section to each cipher's HTML page, providing clear instructions for encryption and decryption.

Also implements input validation in the corresponding JavaScript files to ensure that users enter the required text and keys before performing any cryptographic operations. An alert is shown if any of the required fields are empty.